### PR TITLE
Update presentation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,31 +62,35 @@
 
       <h1>Additional Resources</h1>
 
-      <p>Join us for our Friday Workshops!</p>
+      <h3>Link to register for our Friday Workshops:</h3>
 
       <a href="http://iub.libcal.com/calendar/workshops/?cid=1228&t=d&d=0000-00-00&ct%5B%5D=27574&cal%5B%5D=1228" target="_blank">Scholars' Commons Workshops for Digital Tools and Visualization Methods for Humanists</a>
+      
+      <h3>CyberDH and Advanced Visualization Lab Presentations:</h3>
 
-      <h3>Presentations</h3>
+		<a href="https://iu.box.com/v/cyberdh-avl-workshops">View All Current Presentations on Box</a>
 
+		
+		<h2>Presentations include:</h2>
       <ul>
-      <li><a href="https://iu.box.com/s/6izkae2uzdgcg3ufi33pq3gmg5j7kv8g">Introduction to R</a></li>
-      <li><a href="https://iu.box.com/s/1pj6d97t5tjqous9f6ubk5ioqvjuiain">R for Literary Analysis</a></li>
-      <li><a href="https://iu.box.com/v/rtwitter">R for Twitter Analysis</a></li>
+      <li>Introduction to R</li>
+      <li>R for Literary Analysis</li>
+      <li>R for Twitter Analysis</li>
       <h3>Additional CyberDH Presentations</h3>
       <ul>
-         <li><a href="https://iu.box.com/v/photogrammetry">3D Photogrammetry</a></li>
-      	 <li><a href="https://iu.box.com/v/intro-dh">Introduction to Digital Humanities</a></li>
-     	 <li><a href="https://iu.box.com/v/network-graphs">Network Graphs</a></li>
+         <li>3D Photogrammetry</li>
+      	 <li>Introduction to Digital Humanities</li>
+     	 <li>Network Graphs</li>
      	 
       </ul>
       <h3>Additional Advanced Visualization Lab Presentations</h3>
       <ul>
-      	 <li><a href="https://iu.box.com/v/3d-scan-print">3D Object Acquisition and Printing</a></li>
-      	 <li><a href="https://iu.box.com/v/advanced-media">Advanced Media</a></li>
-      	 <li><a href="https://iu.box.com/v/augmented-reality">Augmented Reality</a></li>
-      	 <li><a href="https://iu.box.com/v/intro-advanced-visualization">Introduction to Advanced Visualization</a></li>
-      	 <li><a href="https://iu.box.com/v/iqtables">IQ Tables & Touch Enabled Software</a></li>
-      	 <li><a href="https://iu.box.com/v/avl-virtual-reality">Virtual Reality</a></li>
+      	 <li>3D Object Acquisition and Printing</li>
+      	 <li>Advanced Media</li>
+      	 <li>Augmented Reality (AR)</li>
+      	 <li>Introduction to Advanced Visualization</li>
+      	 <li>IQ Tables & Touch Enabled Software</li>
+      	 <li>Virtual Reality (VR)</li>
       </ul>
       </ul>
       


### PR DESCRIPTION
Eliminated individual presentation links in exchange for “PresentationsPublic” folder link (line 71). This link will have the most updated versions of all presentations and be available for users with/without Box account.